### PR TITLE
Fix default model selection

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { ChatMessage, UserType } from '../types/types';
 import { ModelSelector } from './ModelSelector';
 import { getDefaultModel } from '../services/aiService';
+import { isProviderAvailable } from '../utils/envValidator';
 import { PaperAirplaneIcon, StopIcon } from './icons';
 
 interface ChatPanelProps {
@@ -20,7 +21,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   onSendMessage, 
   isLoading, 
   onStop, 
-  chatModel = getDefaultModel('gemini'),
+  chatModel = getDefaultModel(isProviderAvailable('gemini') ? 'gemini' : 'openrouter'),
   onChatModelChange,
   isChatAvailable = true,
   title

--- a/src/components/PlanDisplay.tsx
+++ b/src/components/PlanDisplay.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { ModelSelector } from './ModelSelector';
 import { LoadingSpinner } from './LoadingSpinner';
 import { getDefaultModel } from '../services/aiService';
+import { isProviderAvailable } from '../utils/envValidator';
 import { CheckCircleIcon, PencilSquareIcon } from './icons';
 
 interface PlanDisplayProps {
@@ -27,7 +28,7 @@ export const PlanDisplay: React.FC<PlanDisplayProps> = ({
   isLoadingHtml,
   showGenerateButton = true, 
   isCompactView = false,
-  htmlModel = getDefaultModel('gemini'),
+  htmlModel = getDefaultModel(isProviderAvailable('gemini') ? 'gemini' : 'openrouter'),
   onHtmlModelChange,
   onToggleRefine,
   showRefineButton,

--- a/src/hooks/useWebsiteGeneration.ts
+++ b/src/hooks/useWebsiteGeneration.ts
@@ -15,6 +15,7 @@ import { ActiveTab, ChatMessage, UserType } from '../types/types';
 import type { AppStage } from '../App';
 import { createLogger } from '../utils/logger';
 import { ERROR_MESSAGES } from '../utils/constants';
+import { getAvailableProviders } from '../utils/envValidator';
 
 const logger = createLogger('useWebsiteGeneration');
 
@@ -67,14 +68,24 @@ export interface UseWebsiteGenerationReturn {
 }
 
 export function useWebsiteGeneration({ ai }: UseWebsiteGenerationProps): UseWebsiteGenerationReturn {
+  // Determine available providers to select sensible defaults
+  const availableProviders = getAvailableProviders();
+  const geminiAvailable = availableProviders.includes('gemini');
+  const openrouterAvailable = availableProviders.includes('openrouter');
+
+  // Choose defaults based on available API keys
+  const defaultPlanProvider = geminiAvailable ? 'gemini' : 'openrouter';
+  const defaultHtmlProvider = openrouterAvailable ? 'openrouter' : 'gemini';
+  const defaultChatProvider = geminiAvailable ? 'gemini' : openrouterAvailable ? 'openrouter' : 'gemini';
+
   // State management
   const [reportText, setReportText] = useState<string>('');
   const [generatedPlan, setGeneratedPlan] = useState<string | null>(null);
   const [generatedHtml, setGeneratedHtml] = useState<string | null>(null);
-  const [planModel, setPlanModel] = useState<string>(getDefaultModel('gemini'));
-  const [htmlModel, setHtmlModel] = useState<string>(getDefaultModel('openrouter'));
-  const [chatModel, setChatModel] = useState<string>(getDefaultModel('gemini'));
-  const [planChatModel, setPlanChatModel] = useState<string>(getDefaultModel('gemini'));
+  const [planModel, setPlanModel] = useState<string>(getDefaultModel(defaultPlanProvider));
+  const [htmlModel, setHtmlModel] = useState<string>(getDefaultModel(defaultHtmlProvider));
+  const [chatModel, setChatModel] = useState<string>(getDefaultModel(defaultChatProvider));
+  const [planChatModel, setPlanChatModel] = useState<string>(getDefaultModel(defaultPlanProvider));
   
   // 添加状态来跟踪最后使用的plan文本（可能是用户编辑过的）
   const [lastUsedPlanText, setLastUsedPlanText] = useState<string>('');


### PR DESCRIPTION
## Summary
- choose initial models based on available API keys
- set default models for `ChatPanel` and `PlanDisplay` using available providers

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_683fae004628832aa9f7585d3c2a2ad7