### PR TITLE
Add DOCTYPE to optimized HTML output

### DIFF
--- a/src/components/OutputDisplay.tsx
+++ b/src/components/OutputDisplay.tsx
@@ -170,8 +170,8 @@ export const OutputDisplay: React.FC<OutputDisplayProps> = ({
       });`;
       headElement.appendChild(scriptElement);
       
-      // 序列化回HTML字符串
-      return doc.documentElement.outerHTML;
+      // 序列化回HTML字符串并添加 DOCTYPE
+      return `<!DOCTYPE html>\n${doc.documentElement.outerHTML}`;
       
     } catch (error) {
       // 如果DOMParser失败，降级到原始内容


### PR DESCRIPTION
## Summary
- ensure `optimizedHtmlContent` prefixes the serialized HTML with `<!DOCTYPE html>`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fafec958c832a8dc0b7b2de3669a4